### PR TITLE
Link Google credentials with existing Firebase user accounts

### DIFF
--- a/HW_OrderCoffeeApp/Authentication/Services/AppleSignInController.swift
+++ b/HW_OrderCoffeeApp/Authentication/Services/AppleSignInController.swift
@@ -29,164 +29,203 @@
     - 再次登入時從數據庫獲取資料：在用戶再次登入時，從數據庫中讀取用戶的資料（包括名字和電子郵件）。
     - 在 storeAppleUserData 方法中，先嘗試獲取現有的使用者資料。如果資料已經存在，則只更新非空白的全名。
  
+ ---------------------------------------- ---------------------------------------- ----------------------------------------
+
+ C. 當使用者用相同的電子郵件透過不同的登入方式（如 Apple 和 Google）登入時，發生覆蓋 FullName問題 。
+    - 因為 Firebase 會根據電子郵件地址將這些不同的登入方式識別為相同的帳戶。
+    - UID 一致：不論使用者透過哪種方式登入，Firebase 都會為同一個電子郵件地址的使用者分配相同的 UID。
+    - 資料覆蓋：由於 Firebase 使用 UID 作為唯一標識符，後一次登入（例如 Google）會覆蓋前一次登入（例如 Apple）儲存的使用者資料。
+
+ * 解決方式：
+    - 避免資料覆蓋：在儲存使用者資料時，不要覆蓋已有的 fullName。
+    - 區分登入來源：在使用者資料中儲存登入來源，設置 loginProvider，以便在後續操作中區分不同的登入方式。
+    - 修改了 storeAppleUserData 和 storeGoogleUserData ，以避免覆蓋已有的 fullName，並在資料中加入 loginProvider 以記錄登入方式。
+    - 當使用者透過不同方式登入時，只更新 fullName 欄位為空的情況，避免覆蓋之前已儲存的全名。
+    - 這樣可以避免使用者的全名在不同登入方式間被覆蓋，同時保留每次登入時的唯一識別資訊。
+ 
  */
 
 
-// MARK: - 原版沒有取得名字
+// MARK: - 首次登入可以存取姓名資訊，再次登入也可行備用
+
 /*
-import UIKit
-import Firebase
-import AuthenticationServices
-import CryptoKit
+ import UIKit
+ import Firebase
+ import AuthenticationServices
+ import CryptoKit
 
-/// 處理 Apple 相關部分
-class AppleSignInController: NSObject {
-    
-    static let shared = AppleSignInController()
-    
-    private var currentNonce: String?
-    private var signInCompletion: ((Result<AuthDataResult, Error>) -> Void)?
-
-
-    /// 使用 Apple 登入或註冊
-    /// - Parameters:
-    ///   - presentingViewController: 觸發登入流程的 ViewController
-    ///   - completion: 登入或註冊結果的回調
-    func signInWithApple(presentingViewController: UIViewController, completion: @escaping (Result<AuthDataResult, Error>) -> Void) {
-        self.signInCompletion = completion
-        let request = creatAppleIDRequest()
-        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
-        authorizationController.delegate = self
-        authorizationController.presentationContextProvider = self
-        authorizationController.performRequests()
-    }
-    
-    /// 建立 Apple ID 請求
-    private func creatAppleIDRequest() -> ASAuthorizationAppleIDRequest {
-        let appleIDProvider = ASAuthorizationAppleIDProvider()
-        let request = appleIDProvider.createRequest()
-        request.requestedScopes = [.fullName, .email]
-        let nonce = randomNonceString()
-        currentNonce = nonce
-        request.nonce = sha256(nonce)
-        return request
-    }
-    
-    
-    /// 儲存 Apple 使用者資料
-    /// - Parameters:
-    ///   - authResult: Firebase 驗證結果
-    ///   - completion: 資料儲存結果的回調
-    private func storeAppleUserData(authResult: AuthDataResult, completion: @escaping (Result<Void, Error>) -> Void) {
-        let db = Firestore.firestore()
-        let user = authResult.user
-        let userRef = db.collection("users").document(user.uid)
-        
-        userRef.setData([
-            "uid": user.uid,
-            "email": user.email ?? "",
-            "fullName": user.displayName ?? ""
-        ], merge: true) { error in
-            if let error = error {
-                completion(.failure(error))
-            } else {
-                completion(.success(()))
-            }
-        }
-    }
+ /// 處理 Apple 相關部分
+ class AppleSignInController: NSObject {
      
-}
+     static let shared = AppleSignInController()
+     
+     private var currentNonce: String?
+     private var signInCompletion: ((Result<AuthDataResult, Error>) -> Void)?
 
-// MARK: - ASAuthorizationControllerPresentationContextProviding
-extension AppleSignInController: ASAuthorizationControllerPresentationContextProviding {
-    
-    /// 返回當前的 Presentation Anchor
-    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        return UIApplication.shared.windows.first!
-    }
-    
-    /// 產生隨機字串
-    /// - Parameter length: 字串長度
-    /// - Returns: 隨機字串
-    private func randomNonceString(length: Int = 32) -> String {
-        precondition(length > 0)
-        var randomBytes = [UInt8](repeating: 0, count: length)
-        let errorCode = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
-        if errorCode != errSecSuccess {
-            fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
-        }
-        
-        let charset: [Character] = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
-        let nonce = randomBytes.map { byte in
-            // 從字符集中隨機挑選字符
-            charset[Int(byte) % charset.count]
-        }
-        return String(nonce)
-    }
 
-    /// SHA256 加密
-    /// - Parameter input: 要加密的字串
-    /// - Returns: 加密後的字串
-    private func sha256(_ input: String) -> String {
-        let inputData = Data(input.utf8)
-        let hashedData = SHA256.hash(data: inputData)
-        let hashString = hashedData.compactMap {
-            String(format: "%02x", $0)
-        }.joined()
-        
-        return hashString
-    }
+     /// 使用 Apple 登入或註冊
+     /// - Parameters:
+     ///   - presentingViewController: 觸發登入流程的 ViewController
+     ///   - completion: 登入或註冊結果的回調
+     func signInWithApple(presentingViewController: UIViewController, completion: @escaping (Result<AuthDataResult, Error>) -> Void) {
+         self.signInCompletion = completion
+         let request = creatAppleIDRequest()
+         let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+         authorizationController.delegate = self
+         authorizationController.presentationContextProvider = self
+         authorizationController.performRequests()
+     }
+     
+     /// 建立 Apple ID 請求
+     private func creatAppleIDRequest() -> ASAuthorizationAppleIDRequest {
+         let appleIDProvider = ASAuthorizationAppleIDProvider()
+         let request = appleIDProvider.createRequest()
+         request.requestedScopes = [.fullName, .email]
+         let nonce = randomNonceString()
+         currentNonce = nonce
+         request.nonce = sha256(nonce)
+         return request
+     }
 
-}
+     
+     /// 儲存 Apple 使用者資料
+     /// - Parameters:
+     ///   - authResult: Firebase 驗證結果
+     ///   - fullName: 使用者的全名
+     ///   - completion: 資料儲存結果的回調
+     private func storeAppleUserData(authResult: AuthDataResult,fullName: PersonNameComponents?, completion: @escaping (Result<Void, Error>) -> Void) {
+         let db = Firestore.firestore()
+         let user = authResult.user
+         let userRef = db.collection("users").document(user.uid)
+         
+         userRef.getDocument { (document, error) in
+             if let document = document, document.exists, var userData = document.data() {
+                 // 如果 document 已存在，則更新非空白的全名
+                 if let fullName = fullName, let givenName = fullName.givenName, let familyName = fullName.familyName {
+                     if !givenName.isEmpty && !familyName.isEmpty {
+                         userData["fullName"] = "\(givenName) \(familyName)"
+                     }
+                 }
+                 userRef.setData(userData, merge: true) { error in
+                     if let error = error {
+                         completion(.failure(error))
+                     } else {
+                         completion(.success(()))
+                     }
+                 }
+             } else {
+                 // 如果 document 不存在，則建立新的資料
+                 var userData: [String: Any] = [
+                     "uid": user.uid,
+                     "email": user.email ?? ""
+                 ]
+                 
+                 if let fullName = fullName, let givenName = fullName.givenName, let familyName = fullName.familyName {
+                     userData["fullName"] = "\(givenName) \(familyName)"
+                 }
+                 
+                 userRef.setData(userData, merge: true) { error in
+                     if let error = error {
+                         completion(.failure(error))
+                     } else {
+                         completion(.success(()))
+                     }
+                 }
 
-// MARK: - ASAuthorizationControllerDelegate
-extension AppleSignInController: ASAuthorizationControllerDelegate {
-    
-    /// Apple 登入成功的回調
-    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
-        if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
-            guard let nonce = currentNonce else {
-                fatalError("Invalid state: A login callback was received, but no login request was sent.")
-            }
-            guard let appleIDToken = appleIDCredential.identityToken else {
-                print("Unable to fetch identity token")
-                return
-            }
-            guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
-                print("Unable to serialize token string from data: \(appleIDToken.debugDescription)")
-                return
-            }
+             }
+         }
+     }
+     
+ }
+
+ // MARK: - ASAuthorizationControllerPresentationContextProviding
+ extension AppleSignInController: ASAuthorizationControllerPresentationContextProviding {
+     
+     /// 返回當前的 Presentation Anchor
+     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+         return UIApplication.shared.windows.first!
+     }
+     
+     /// 產生隨機字串
+     /// - Parameter length: 字串長度
+     /// - Returns: 隨機字串
+     private func randomNonceString(length: Int = 32) -> String {
+         precondition(length > 0)
+         var randomBytes = [UInt8](repeating: 0, count: length)
+         let errorCode = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
+         if errorCode != errSecSuccess {
+             fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+         }
+         
+         let charset: [Character] = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+         let nonce = randomBytes.map { byte in
+             // 從字符集中隨機挑選字符
+             charset[Int(byte) % charset.count]
+         }
+         return String(nonce)
+     }
+
+     /// SHA256 加密
+     /// - Parameter input: 要加密的字串
+     /// - Returns: 加密後的字串
+     private func sha256(_ input: String) -> String {
+         let inputData = Data(input.utf8)
+         let hashedData = SHA256.hash(data: inputData)
+         let hashString = hashedData.compactMap {
+             String(format: "%02x", $0)
+         }.joined()
+         
+         return hashString
+     }
+
+ }
+
+ // MARK: - ASAuthorizationControllerDelegate
+ extension AppleSignInController: ASAuthorizationControllerDelegate {
+     
+     /// Apple 登入成功的回調
+     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+         if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
+             guard let nonce = currentNonce else {
+                 fatalError("Invalid state: A login callback was received, but no login request was sent.")
+             }
+             guard let appleIDToken = appleIDCredential.identityToken else {
+                 print("Unable to fetch identity token")
+                 return
+             }
+             guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
+                 print("Unable to serialize token string from data: \(appleIDToken.debugDescription)")
+                 return
+             }
              
-            let credential = OAuthProvider.credential(withProviderID: "apple.com", idToken: idTokenString, rawNonce: nonce)
-            Auth.auth().signIn(with: credential) { authResult, error in
-                if let error = error {
-                    self.signInCompletion?(.failure(error))
-                } else if let authResult = authResult {
-                    self.storeAppleUserData(authResult: authResult) { result in
-                        switch result {
-                        case .success:
-                            self.signInCompletion?(.success(authResult))
-                        case .failure(let error):
-                            self.signInCompletion?(.failure(error))
-                        }
-                    }
-                }
-            }
-        }
-    }
-  
-    
-    /// Apple 登入失敗的回調
-    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: any Error) {
-        print("Sign in with Apple errored: \(error)")
-    }
-    
-}
+             let credential = OAuthProvider.appleCredential(withIDToken: idTokenString, rawNonce: nonce, fullName: appleIDCredential.fullName)
+             Auth.auth().signIn(with: credential) { authResult, error in
+                 if let error = error {
+                     self.signInCompletion?(.failure(error))
+                 } else if let authResult = authResult {
+                     self.storeAppleUserData(authResult: authResult, fullName: appleIDCredential.fullName) { result in
+                         switch result {
+                         case .success:
+                             self.signInCompletion?(.success(authResult))
+                         case .failure(let error):
+                             self.signInCompletion?(.failure(error))
+                         }
+                     }
+                 }
+             }
+         }
+     }
+     
+     /// Apple 登入失敗的回調
+     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: any Error) {
+         print("Sign in with Apple errored: \(error)")
+     }
+     
+ }
 */
 
 
-// MARK: - 測試用（首次登入可以存取姓名資訊，但是再次登入也可行）
-
+// MARK: - 測試用
 import UIKit
 import Firebase
 import AuthenticationServices
@@ -238,12 +277,13 @@ class AppleSignInController: NSObject {
         
         userRef.getDocument { (document, error) in
             if let document = document, document.exists, var userData = document.data() {
-                // 如果 document 已存在，則更新非空白的全名
+                // 如果 document 已存在，則僅在 fullName 欄位為空時更新全名
                 if let fullName = fullName, let givenName = fullName.givenName, let familyName = fullName.familyName {
-                    if !givenName.isEmpty && !familyName.isEmpty {
-                        userData["fullName"] = "\(givenName) \(familyName)"
+                    if userData["fullName"] as? String == "" {
+                        userData["fullName"] = "\(familyName) \(givenName)"
                     }
                 }
+                userData["loginProvider"] = "apple"
                 userRef.setData(userData, merge: true) { error in
                     if let error = error {
                         completion(.failure(error))
@@ -251,15 +291,17 @@ class AppleSignInController: NSObject {
                         completion(.success(()))
                     }
                 }
+                
             } else {
                 // 如果 document 不存在，則建立新的資料
                 var userData: [String: Any] = [
                     "uid": user.uid,
-                    "email": user.email ?? ""
+                    "email": user.email ?? "",
+                    "loginProvider": "apple"
                 ]
                 
                 if let fullName = fullName, let givenName = fullName.givenName, let familyName = fullName.familyName {
-                    userData["fullName"] = "\(givenName) \(familyName)"
+                    userData["fullName"] = "\(familyName) \(givenName)"
                 }
                 
                 userRef.setData(userData, merge: true) { error in
@@ -273,6 +315,7 @@ class AppleSignInController: NSObject {
             }
         }
     }
+    
     
 }
 
@@ -315,7 +358,7 @@ extension AppleSignInController: ASAuthorizationControllerPresentationContextPro
         
         return hashString
     }
-
+    
 }
 
 // MARK: - ASAuthorizationControllerDelegate
@@ -353,6 +396,7 @@ extension AppleSignInController: ASAuthorizationControllerDelegate {
             }
         }
     }
+    
     
     /// Apple 登入失敗的回調
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: any Error) {

--- a/HW_OrderCoffeeApp/Authentication/Services/GoogleSignInController.swift
+++ b/HW_OrderCoffeeApp/Authentication/Services/GoogleSignInController.swift
@@ -11,19 +11,70 @@
  那這樣每次登入就等於再次註冊嗎？那這樣會不會影響到使用者的資料呢？
  
  
- 1. 原先的寫法只處理了登入部分，沒注意到對於 Google 登入，註冊和登入實際上是使用相同的邏輯。
-    * 由於 Google 登入後，Firebase 會自動建立用戶帳號，因此需要確保在首次登入時將用戶資料存取到 Firestore 中，這樣在之後獲取用戶資料時就不會出現「User data not found」。
-    * 已經使用了 merge: true，代表在用戶每次登入時，新的用戶資料會被合併到現有的資料中，而不是整個覆蓋。因此，這不會影響到用戶的現有資料，除非明確的在 setData 中覆蓋。
+ A. 原先的寫法只處理了登入部分，沒注意到對於 Google 登入，註冊和登入實際上是使用相同的邏輯。
+    - 由於 Google 登入後，Firebase 會自動建立用戶帳號，因此需要確保在首次登入時將用戶資料存取到 Firestore 中，這樣在之後獲取用戶資料時就不會出現「User data not found」。
+    - 已經使用了 merge: true，代表在用戶每次登入時，新的用戶資料會被合併到現有的資料中，而不是整個覆蓋。因此，這不會影響到用戶的現有資料，除非明確的在 setData 中覆蓋。
  
- 2. 結論：
-    * 登入、註冊基本上是相同的邏輯。
-    * 需要確保在首次登入時將用戶資料存取到 Firestore 中。
-    * 使用 merge: true 可以防止每次登入覆蓋現有的用戶資料。
-    * 這樣就能確保用戶資料在首次登入時被正確存取，並且不會在每次登入時被覆蓋，從而不會影響用戶的現有資料。
+ * 結論：
+    - 登入、註冊基本上是相同的邏輯。
+    - 需要確保在首次登入時將用戶資料存取到 Firestore 中。
+    - 使用 merge: true 可以防止每次登入覆蓋現有的用戶資料。
+    - 這樣就能確保用戶資料在首次登入時被正確存取，並且不會在每次登入時被覆蓋，從而不會影響用戶的現有資料。
+ 
+ 
+ ------------------------- ------------------------- ------------------------- -------------------------
+
+ B. 處理「電子郵件/密碼登入」與「Google 登入」的部分
+    - 主要是因為當使用者使用「電子郵件/密碼」註冊登入之後，接著使用帶有相同 email 的 「Google」 註冊登入，就會發生先前的「電子郵件/密碼」無法使用的問題。
+ 
+ * 解決方式：
+    -  將不同的身份驗證提供者（如 Google、Facebook、電子郵件和密碼等）憑證與現有的 Firebase 使用者帳號進行關聯，以便用戶可以通過任何已關聯的身份驗證方式登入同一個 Firebase 帳號。
+
+    1. 用任意身份驗證提供方登入:
+        - 首先，用戶使用任意身份驗證方式登入，例如電子郵件和密碼、Google 或 Facebook。
+    2. 開始新的身份驗證提供方登入流程：
+        - 按照新身份驗證提供方的登入流程逐步進行，直到需要調用 signInWith 方法時停止。例如，獲取用戶的 Google ID 令牌或電子郵件地址和密碼。
+    3. 獲取新身份驗證提供方的憑證：
+        - 根據不同的身份驗證提供方，獲取相應的 AuthCredential 對象。
+    4. 將新身份驗證提供方的憑證與已登入用戶的帳號關聯：
+        - 使用當前已登入用戶的 link(with:completion:) 方法將新身份驗證提供方的憑證與該帳號關聯。
+ 
+ * 流程：
+    1. Google 登入或註冊：
+        - signInWithGoogle 負責處理 Google 登入流程。它會使用 Google SDK 來發起登入請求，並在登入成功後獲取 idToken 和 accessToken。
+    2. 將 Google 憑證與現有帳號關聯：
+        - linkGoogleCredential 會檢查當前是否有已登入的使用者。如果有，它會嘗試將 Google 憑證與該使用者帳號關聯。
+        - 如果關聯失敗（因為該憑證已經與另一個帳號關聯），它會改用 Google 憑證進行登入。
+    3. 使用 Google 憑證登入：
+        - signInWithGoogleCredential 負責使用 Google 憑證進行登入，並在登入成功後存取使用者資料。
+    4. 存取 Google 使用者資料：
+        - storeGoogleUserData 方法會檢查 Firestore 中是否已經存在該使用者的資料。如果存在，它會更新資料，否則會創建新資料。
+ 
+ * 合併數據的情境
+    1. 多個身份驗證提供者：
+        -  用戶可能先使用電子郵件註冊，然後再使用 Google 登錄。此時，將這兩種不同的身份驗證方式關聯到同一個 Firebase 帳戶。
+    2. 避免帳戶衝突：
+        - 當用戶嘗試使用 Google 憑證登錄，但該憑證已經與另一個 Firebase 帳戶關聯時，連結操作將失敗。在這種情況下，需要讓用戶登錄並合併數據，以確保用戶的數據保持一致，不會丟失。
+
+ * 合併數據的必要性在於保持用戶數據的一致性和完整性：
+    1. 用戶改變身份驗證方式：
+        - 用戶可能會從使用電子郵件和密碼註冊轉變為使用 Google 登錄，或相反。確保無論用戶使用哪種身份驗證方式，都能訪問到相同的帳戶數據。
+    2. 避免重複帳戶：
+        - 如果不合併數據，用戶可能會無意中創建多個帳戶，這會導致數據分散，給用戶體驗帶來不便。
+ 
+ * 注意部分：
+    - 每次登錄時都要檢查並更新用戶資料，以確保最新的身份驗證信息被正確存儲。
+    - 當用戶嘗試用新的身份驗證提供者登錄時，必須確保用戶是相同的 Firebase 帳號。
+    - 如果用戶的 fullName 在 Google 和 Apple 登錄時不同，必須決定如何處理這種情況（EX: 保留最初註冊時的名字或者詢問用戶希望使用哪一個名字）。
+ 
+ ------------------------- ------------------------- ------------------------- -------------------------
+
+
  */
 
 
-
+// 備用
+/*
 import UIKit
 import Firebase
 import GoogleSignIn
@@ -76,20 +127,182 @@ class GoogleSignInController {
         let user = authResult.user
         let userRef = db.collection("users").document(user.uid)
         
-        userRef.setData([
-            "uid": user.uid,
-            "email": user.email ?? "",
-            "fullName": user.displayName ?? ""
-        ], merge: true) { error in
-            if let error = error {
-                completion(.failure(error))
+        userRef.getDocument { (document, error) in
+            if let document = document, document.exists, var userData = document.data() {
+                // 如果 document 已存在，則僅在 fullName 欄位為空時更新全名
+                if let displayName = user.displayName, userData["fullName"] as? String == "" {
+                    userData["fullName"] = displayName
+                }
+                userData["loginProvider"] = "google"
+                userRef.setData(userData, merge: true) { error in
+                    if let error = error {
+                        completion(.failure(error))
+                    } else {
+                        completion(.success(()))
+                    }
+                }
             } else {
-                completion(.success(()))
+                // 如果 document 不存在，則建立新的資料
+                var userData: [String: Any] = [
+                    "uid": user.uid,
+                    "email": user.email ?? "",
+                    "loginProvider": "google"
+                ]
+                
+                if let displayName = user.displayName {
+                    userData["fullName"] = displayName
+                }
+                
+                userRef.setData(userData, merge: true) { error in
+                    if let error = error {
+                        completion(.failure(error))
+                    } else {
+                        completion(.success(()))
+                    }
+                }
+            }
+        }
+    }
+
+}
+*/
+
+
+// 測試（不同的身份驗證提供方（如 Google、Facebook、電子郵件和密碼等）憑證與現有的 Firebase 使用者帳號進行關聯）
+
+import UIKit
+import Firebase
+import GoogleSignIn
+
+/// 處理 Google 相關部分
+class GoogleSignInController {
+    
+    static let shared = GoogleSignInController()
+    
+    /// 使用google 登入 或 註冊
+    func signInWithGoogle(presentingViewController: UIViewController, completion: @escaping (Result<AuthDataResult, Error>) -> Void) {
+        guard let clientID = FirebaseApp.app()?.options.clientID else { return }
+        
+        let config = GIDConfiguration(clientID: clientID)
+        GIDSignIn.sharedInstance.configuration = config
+        
+        GIDSignIn.sharedInstance.signIn(withPresenting: presentingViewController) { result, error in
+            if let error = error {
+                print("Google Sign-In error: \(error.localizedDescription)")
+                completion(.failure(error))
+                return
+            }
+            
+            guard let user = result?.user, let idToken = user.idToken?.tokenString else {
+                print("Google Sign-In failed to get user or idToken")
+                completion(.failure(NSError(domain: "GoogleSignInError", code: -1, userInfo: [NSLocalizedDescriptionKey: "Google sign-in failed."])))
+                return
+            }
+            
+            print("Google Sign-In successful. User: \(user.profile?.name ?? "Unknown"), Email: \(user.profile?.email ?? "Unknown")")
+
+            let credential = GoogleAuthProvider.credential(withIDToken: idToken, accessToken: user.accessToken.tokenString)
+            self.linkGoogleCredential(credential, completion: completion)
+        }
+    }
+    
+    
+    /// 將 Google 憑證與現有帳號關聯
+    private func linkGoogleCredential(_ credential: AuthCredential, completion: @escaping (Result<AuthDataResult, Error>) -> Void) {
+        if let currentUser = Auth.auth().currentUser {
+            print("Current user is signed in. Linking Google credential...")
+            currentUser.link(with: credential) { authResult, error in
+                if let error = error {
+                    // 如果連結失敗，嘗試登入並合併數據
+                    print("Linking Google credential failed: \(error.localizedDescription). Trying to sign in instead.")
+                    self.signInWithGoogleCredential(credential, completion: completion)
+                } else if let authResult = authResult {
+                    // 連結成功，調用 storeGoogleUserData 保存用戶數據。
+                    print("Linking Google credential successful")
+                    self.storeGoogleUserData(authResult: authResult) { result in
+                        switch result {
+                        case .success:
+                            completion(.success(authResult))
+                        case .failure(let error):
+                            completion(.failure(error))
+                        }
+                    }
+                }
+            }
+        } else {
+            // 如果不存在相同電子郵件的帳戶，則透過 signInWithGoogleCredential 建立一個新的 Google 憑證帳戶。
+            print("No current user. Signing in with Google credential...")
+            self.signInWithGoogleCredential(credential, completion: completion)
+        }
+    }
+    
+    /// 使用 Google 憑證登入
+    private func signInWithGoogleCredential(_ credential: AuthCredential, completion: @escaping (Result<AuthDataResult, Error>) -> Void) {
+        Auth.auth().signIn(with: credential) { authResult, error in
+            if let error = error {
+                print("Sign in with Google credential failed: \(error.localizedDescription)")
+                completion(.failure(error))
+            } else if let authResult = authResult {
+                print("Sign in with Google credential successful")
+                self.storeGoogleUserData(authResult: authResult) { result in
+                    switch result {
+                    case .success:
+                        completion(.success(authResult))
+                    case .failure(let error):
+                        completion(.failure(error))
+                    }
+                }
             }
         }
     }
     
+    /// 存取 Google 使用者資料
+    private func storeGoogleUserData(authResult: AuthDataResult, completion: @escaping (Result<Void, Error>) -> Void) {
+        let db = Firestore.firestore()
+        let user = authResult.user
+        let userRef = db.collection("users").document(user.uid)
+        
+        userRef.getDocument { (document, error) in
+            if let document = document, document.exists, var userData = document.data() {
+                // 如果 document 已存在，則僅在 fullName 欄位為空時更新全名
+                if let displayName = user.displayName, userData["fullName"] as? String == "" {
+                    print("Updating existing user data with Google display name: \(displayName)")
+                    userData["fullName"] = displayName
+                }
+                userData["loginProvider"] = "google"
+                userRef.setData(userData, merge: true) { error in
+                    if let error = error {
+                        print("Failed to update user data: \(error.localizedDescription)")
+                        completion(.failure(error))
+                    } else {
+                        print("User data updated successfully")
+                        completion(.success(()))
+                    }
+                }
+            } else {
+                // 如果 document 不存在，則建立新的資料
+                var userData: [String: Any] = [
+                    "uid": user.uid,
+                    "email": user.email ?? "",
+                    "loginProvider": "google"
+                ]
+                
+                if let displayName = user.displayName {
+                    print("Creating new user data with Google display name: \(displayName)")
+                    userData["fullName"] = displayName
+                }
+                
+                userRef.setData(userData, merge: true) { error in
+                    if let error = error {
+                        print("Failed to create user data: \(error.localizedDescription)")
+                        completion(.failure(error))
+                    } else {
+                        print("User data created successfully")
+                        completion(.success(()))
+                    }
+                }
+            }
+        }
+    }
+
 }
-
-
-

--- a/HW_OrderCoffeeApp/Authentication/View Controllers/LoginViewController.swift
+++ b/HW_OrderCoffeeApp/Authentication/View Controllers/LoginViewController.swift
@@ -164,6 +164,8 @@ class LoginViewController: UIViewController {
 
 // MARK: - 視圖佈局分離版本
 import UIKit
+import FirebaseAuth
+
 
 /// 登入介面
 class LoginViewController: UIViewController {
@@ -229,7 +231,7 @@ class LoginViewController: UIViewController {
         }
         
     }
-    
+ 
     
     // MARK: - 處理Google登入
     @objc private func googleLoginButtonTapped() {

--- a/HW_OrderCoffeeApp/Services/FirebaseController.swift
+++ b/HW_OrderCoffeeApp/Services/FirebaseController.swift
@@ -24,7 +24,15 @@
  
  3. 將 loadUserOrders 與 getCurrentUserDetails 整合在一起，藉此减少重複調用。
 
- 4. 歷史訂單由 FirebaseController 獲取。
+ 4. 避免覆蓋現有資料並區分不同登入來源的方法：
+    * 避免覆蓋現有資料：
+        - 在更新資料庫中的使用者資料時，應檢查是否有必要更新每個欄位。例如，只有在該欄位為空或有特定更新需求時才更新。
+    * 儲存登入來源：
+        - 儲存登入來源（如 Google、Apple 等）有助於後續對使用者行為的分析和管理。
+    * 資料合併：
+        - 當需要更新使用者資料時，使用合併操作（如 Firebase 的 merge: true）來確保新資料不會覆蓋掉已有的重要資料。
+    * 唯一識別符（UID）：
+        - 使用唯一識別符（如 Firebase 的 UID）來管理使用者資料，確保每個使用者都有一個唯一的標識符。
  */
 
 
@@ -32,6 +40,7 @@
  import UIKit
  import Firebase
 
+ /// 處理 Firebase 資料庫相關
  class FirebaseController {
      
      static let shared = FirebaseController()
@@ -54,7 +63,7 @@
      }
      
      // MARK: - Email登入、註冊相關
-
+     
      /// 創建新用戶，並將用戶資料儲存到 Firestore。
      func registerUser(withEmail email: String, password: String, fullName: String, completion: @escaping (Result<AuthDataResult, Error>) -> Void) {
          Auth.auth().createUser(withEmail: email, password: password) { (result, error) in
@@ -65,7 +74,8 @@
                  db.collection("users").document(result.user.uid).setData([
                      "email": email,
                      "fullName": fullName,
-                     "uid": result.user.uid
+                     "uid": result.user.uid,
+                     "loginProvider": "email"
                  ], merge: true) { error in
                      if let error = error {
                          completion(.failure(error))
@@ -76,7 +86,6 @@
              }
          }
      }
-     
      
      /// 使用電子郵件和密碼進行用戶登入
      func loginUser(withEmail email: String, password: String, completion: @escaping (Result<AuthDataResult, Error>) -> Void) {
@@ -136,7 +145,6 @@
 
 
 // MARK: - 測試修改用
-
 import UIKit
 import Firebase
 
@@ -163,7 +171,7 @@ class FirebaseController {
     }
     
     // MARK: - Email登入、註冊相關
-
+    
     /// 創建新用戶，並將用戶資料儲存到 Firestore。
     func registerUser(withEmail email: String, password: String, fullName: String, completion: @escaping (Result<AuthDataResult, Error>) -> Void) {
         Auth.auth().createUser(withEmail: email, password: password) { (result, error) in
@@ -174,7 +182,8 @@ class FirebaseController {
                 db.collection("users").document(result.user.uid).setData([
                     "email": email,
                     "fullName": fullName,
-                    "uid": result.user.uid
+                    "uid": result.user.uid,
+                    "loginProvider": "email"
                 ], merge: true) { error in
                     if let error = error {
                         completion(.failure(error))
@@ -240,6 +249,15 @@ class FirebaseController {
     }
     
 }
+
+
+
+
+
+
+
+
+
 
 
 // MARK: - 先移除掉（目前用不到）


### PR DESCRIPTION
- Add linkGoogleCredential method to handle linking Google credentials with existing Firebase user accounts.
- Update signInWithGoogle method to use linkGoogleCredential.
- Add detailed logging to track the flow and potential issues.
- Ensure user data is stored correctly after linking or signing in with Google.