### PR TITLE
Add subcategory headers for favorite drinks in FavoritesViewController

### DIFF
--- a/HW_OrderCoffeeApp.xcodeproj/project.pbxproj
+++ b/HW_OrderCoffeeApp.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		9353741D2C9EB58300794A63 /* FavoritesLayoutProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9353741C2C9EB58300794A63 /* FavoritesLayoutProvider.swift */; };
 		935374212CA2F02000794A63 /* Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935374202CA2F02000794A63 /* Notifications.swift */; };
 		935374292CA4502B00794A63 /* NoFavoritesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935374282CA4502B00794A63 /* NoFavoritesView.swift */; };
+		9353742B2CA8128D00794A63 /* FavoritesDrinkHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9353742A2CA8128D00794A63 /* FavoritesDrinkHeaderView.swift */; };
 		936CFFBD2C6BBBED004B8724 /* HW_OrderCoffeeAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 936CFFBC2C6BBBED004B8724 /* HW_OrderCoffeeAppUITests.swift */; };
 		936CFFBF2C6BBBED004B8724 /* HW_OrderCoffeeAppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 936CFFBE2C6BBBED004B8724 /* HW_OrderCoffeeAppUITestsLaunchTests.swift */; };
 		936CFFC62C6C71E7004B8724 /* UserProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 936CFFC52C6C71E7004B8724 /* UserProfileViewController.swift */; };
@@ -180,6 +181,7 @@
 		9353741C2C9EB58300794A63 /* FavoritesLayoutProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesLayoutProvider.swift; sourceTree = "<group>"; };
 		935374202CA2F02000794A63 /* Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notifications.swift; sourceTree = "<group>"; };
 		935374282CA4502B00794A63 /* NoFavoritesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoFavoritesView.swift; sourceTree = "<group>"; };
+		9353742A2CA8128D00794A63 /* FavoritesDrinkHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoritesDrinkHeaderView.swift; sourceTree = "<group>"; };
 		936CFFBA2C6BBBED004B8724 /* HW_OrderCoffeeAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HW_OrderCoffeeAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		936CFFBC2C6BBBED004B8724 /* HW_OrderCoffeeAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HW_OrderCoffeeAppUITests.swift; sourceTree = "<group>"; };
 		936CFFBE2C6BBBED004B8724 /* HW_OrderCoffeeAppUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HW_OrderCoffeeAppUITestsLaunchTests.swift; sourceTree = "<group>"; };
@@ -495,12 +497,45 @@
 			children = (
 				935374112C9C5C6900794A63 /* FavoritesViewController.swift */,
 				935374142C9C5CD000794A63 /* FavoritesHandler.swift */,
-				935374282CA4502B00794A63 /* NoFavoritesView.swift */,
+				9353741C2C9EB58300794A63 /* FavoritesLayoutProvider.swift */,
+				9353742A2CA8128D00794A63 /* FavoritesDrinkHeaderView.swift */,
 				935374162C9C5CF300794A63 /* FavoritesView.swift */,
 				935374182C9C601200794A63 /* FavoriteDrinkCell.swift */,
-				9353741C2C9EB58300794A63 /* FavoritesLayoutProvider.swift */,
+				935374282CA4502B00794A63 /* NoFavoritesView.swift */,
+				9353742D2CA92DD400794A63 /* Handler */,
+				9353742F2CA92DF700794A63 /* Layouts */,
+				9353742E2CA92DE100794A63 /* Views */,
+				9353742C2CA92DC800794A63 /* View Controllers */,
 			);
 			path = Favorites;
+			sourceTree = "<group>";
+		};
+		9353742C2CA92DC800794A63 /* View Controllers */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = "View Controllers";
+			sourceTree = "<group>";
+		};
+		9353742D2CA92DD400794A63 /* Handler */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Handler;
+			sourceTree = "<group>";
+		};
+		9353742E2CA92DE100794A63 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		9353742F2CA92DF700794A63 /* Layouts */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Layouts;
 			sourceTree = "<group>";
 		};
 		936CFFB32C6BA81F004B8724 /* FirebaseTests */ = {
@@ -1098,6 +1133,7 @@
 				93B9DC872C3661DF0050BC3F /* MainTabBarController.swift in Sources */,
 				9352913F2C8843E40018B060 /* DrinksCategoryHandler.swift in Sources */,
 				93755C332C8351AA002570A5 /* MenuViewController.swift in Sources */,
+				9353742B2CA8128D00794A63 /* FavoritesDrinkHeaderView.swift in Sources */,
 				93B9DC762C3042710050BC3F /* MenuLayoutProvider.swift in Sources */,
 				935374292CA4502B00794A63 /* NoFavoritesView.swift in Sources */,
 				93755C352C83520A002570A5 /* MenuCollectionHandler.swift in Sources */,

--- a/HW_OrderCoffeeApp/Favorites/FavoritesDrinkHeaderView.swift
+++ b/HW_OrderCoffeeApp/Favorites/FavoritesDrinkHeaderView.swift
@@ -1,0 +1,60 @@
+//
+//  FavoritesDrinkHeaderView.swift
+//  HW_OrderCoffeeApp
+//
+//  Created by 曹家瑋 on 2024/9/28.
+//
+
+import UIKit
+
+/// 用來顯示 subcategory 的標題。
+class FavoritesDrinkHeaderView: UICollectionReusableView {
+    
+    static let reuseIdentifier = "FavoritesDrinkHeaderView"
+    
+    // MARK: - UI Element
+    
+    let titleLabel = FavoritesDrinkHeaderView.createLabel(fontSize: 25, weight: .bold, textColor: .black)
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup Methods
+    
+    private func setupView() {
+        addSubview(titleLabel)
+        
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8)
+        ])
+    }
+    
+    // MARK: - Factory Methods
+    
+    private static func createLabel(fontSize: CGFloat, weight: UIFont.Weight, textColor: UIColor) -> UILabel {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: fontSize, weight: weight)
+        label.textColor = textColor
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }
+    
+    // MARK: - Configuration
+    
+    /// 設置 subcategory
+    func configure(with title: String) {
+        titleLabel.text = title
+    }
+    
+}

--- a/HW_OrderCoffeeApp/Favorites/FavoritesLayoutProvider.swift
+++ b/HW_OrderCoffeeApp/Favorites/FavoritesLayoutProvider.swift
@@ -63,10 +63,22 @@ class FavoritesLayoutProvider {
     private static func createFavoritesLayoutSection() -> NSCollectionLayoutSection {
         let item = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(100)))
         let group = NSCollectionLayoutGroup.vertical(layoutSize: NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(100)), subitems: [item])
+        
         let section = NSCollectionLayoutSection(group: group)
         section.interGroupSpacing = 10
         section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10)
+        
+        // 添加 section header
+        section.boundarySupplementaryItems = [createSectionHeader()]
+        
         return section
+    }
+    
+    /// 創建 section header
+    private static func createSectionHeader() -> NSCollectionLayoutBoundarySupplementaryItem {
+        let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(60))
+        let header = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: headerSize, elementKind: UICollectionView.elementKindSectionHeader, alignment: .top)
+        return header
     }
     
 }

--- a/HW_OrderCoffeeApp/Favorites/FavoritesView.swift
+++ b/HW_OrderCoffeeApp/Favorites/FavoritesView.swift
@@ -43,6 +43,7 @@ class FavoritesView: UIView {
     /// 註冊所有`自訂義的 cell`
     private func registerCells() {
         collectionView.register(FavoriteDrinkCell.self, forCellWithReuseIdentifier: FavoriteDrinkCell.reuseIdentifier)
+        collectionView.register(FavoritesDrinkHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: FavoritesDrinkHeaderView.reuseIdentifier)
     }
     
     // MARK: - Factory Method


### PR DESCRIPTION
1. Added FavoritesDrinkHeaderView.swift:
   - Displays section headers based on subcategory names in the favorites list.

2. Updated MenuController.swift:
   - Added loadSubcategoryById to fetch subcategory details for favorite drinks and display subcategory titles as section headers in FavoritesViewController.

3. Updated FavoritesView.swift:
   - Registered FavoritesDrinkHeaderView for use as section headers.

4. Updated FavoritesLayoutProvider.swift:
   - Added createSectionHeader to generate section headers based on subcategory titles.

5. Updated FavoritesViewController.swift:
   - Refined fetchDrinks to load drinks from Firestore based on user's favorite drinks, categorize them by subcategory, and update the view to reflect the order of `favoriteDrinks`.
   - Implemented appendDrinkToSubcategory to add drinks to the correct subcategory list or create a new subcategory if it doesn't exist.
   - Added loadSubcategoryAndDrink to load both subcategory titles and associated drinks from Firestore.

6. Updated FavoritesHandler.swift:
   - Adjusted section handling to use subcategory names as section keys, ensuring all drinks from the same subcategory are displayed together.
   - Implemented configureSectionHeaders to provide section headers via supplementaryViewProvider.
   - Updated updateSnapshot to categorize and display drinks in their respective subcategories while maintaining order. Displays "No favorites" view if the list is empty, otherwise shows the drinks.