### PR TITLE
Fix button title color issue in AlertService

### DIFF
--- a/HW_OrderCoffeeApp/Services/AlertService.swift
+++ b/HW_OrderCoffeeApp/Services/AlertService.swift
@@ -5,6 +5,26 @@
 //  Created by 曹家瑋 on 2023/12/15.
 //
 
+// MARK: - 問題：UIAlertController 按鈕顏色變成不一致
+
+/*
+ ## 問題：UIAlertController 按鈕顏色變成不一致
+
+    - 在使用 UIAlertController 顯示警告彈窗時，按鈕的文字顏色預設應該為藍色，但在某些情況下按鈕顏色會變成黑色。
+    - 例如，當按鈕被點擊後，按鈕的顏色從藍色變成黑色，而非保持原本的藍色。
+
+ * 原因：
+
+    - UIAlertController 中的按鈕顏色受 UIView 的 tintColor 影響。
+    - 如果警告框所在的視圖或父視圖的 tintColor 被更改，這可能導致按鈕顏色變得不一致，從而出現按鈕顏色變成黑色的情況。
+
+ * 解決方法：
+
+    - 使用 setValue(_:forKey:) 方法顯式設定按鈕的文字顏色。
+    - 使用 setValue(_:forKey:) 方法設置按鈕的 titleTextColor，可以確保按鈕的文字顏色無論在按下前或按下後，都保持預期的顏色。
+    - 這樣的顯式設置可以避免因為視圖或系統主題的變化而導致顏色顯示異常。
+ */
+
 import UIKit
 
 /// 警告視窗
@@ -17,15 +37,30 @@ class AlertService {
     ///   - inViewController: 彈窗所顯示的視圖控制器
     ///   - showCancelButton: 是否顯示取消按鈕，默認為 false
     ///   - completion: 用戶點擊確定後執行的操作
+    /// - Note: 顯式設置按鈕的文字顏色以確保在某些視圖或主題設定影響下仍保持一致顯示。
     static func showAlert(withTitle title: String, message: String, inViewController viewController: UIViewController, showCancelButton: Bool = false, completion: (() -> Void)? = nil) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "確定", style: .default, handler: { _ in
+        
+        let confirmAction = createAlertAction(title: "確定", style: .default, color: UIColor.deepGreen) {
             completion?()
-        }))
-        if showCancelButton {
-            alert.addAction(UIAlertAction(title: "取消", style: .cancel, handler: nil))
         }
+        alert.addAction(confirmAction)
+        
+        if showCancelButton {
+            let cancelAction = createAlertAction(title: "取消", style: .cancel, color: UIColor.deepGreen)
+            alert.addAction(cancelAction)
+        }
+        
         viewController.present(alert, animated: true, completion: nil)
     }
     
+    /// 按鈕創建
+    private static func createAlertAction(title: String, style: UIAlertAction.Style, color: UIColor, handler: (() -> Void)? = nil) -> UIAlertAction {
+        let action = UIAlertAction(title: title, style: style) { _ in
+            handler?()
+        }
+        action.setValue(color, forKey: "titleTextColor")
+        return action
+    }
+
 }


### PR DESCRIPTION
* Issue:
  - In some cases, the button title color in UIAlertController appears as black instead of the default blue.

* Fix in AlertService.swift:
  - Added `createAlertAction()` to handle the creation of alert buttons.
  - Used `setValue(_:forKey:)` to set the `titleTextColor`, ensuring the button text color remains consistent and correct, both before and after the button is pressed.