### PR TITLE
Refactor EditProfile: Optimize parameter handling and validation

### DIFF
--- a/HW_OrderCoffeeApp/EditProfile/Cells/ProfileTextFieldCell.swift
+++ b/HW_OrderCoffeeApp/EditProfile/Cells/ProfileTextFieldCell.swift
@@ -66,10 +66,9 @@
  - 在 `EditProfileTableHandler` 中的 `configureCell` 方法中根據 `fieldType` 和現有資料動態設置輸入框：
 
  ```swift
- cell.configure(fieldType: .name, text: profileEditModel.fullName)
  cell.onTextChanged = { [weak self] updatedText in
-     guard let self = self else { return }
-     var updatedModel = profileEditModel
+     guard let self = self, let updatedText = updatedText else { return }
+     guard var updatedModel = self.delegate?.getProfileEditModel() else { return }
      updatedModel.fullName = updatedText
      self.delegate?.updateProfileEditModel(updatedModel)
  }

--- a/HW_OrderCoffeeApp/EditProfile/Delegates/EditProfileTableHandlerDelegate.swift
+++ b/HW_OrderCoffeeApp/EditProfile/Delegates/EditProfileTableHandlerDelegate.swift
@@ -56,8 +56,8 @@
 
  ```swift
  cell.onTextChanged = { [weak self] updatedText in
-     guard let self = self else { return }
-     var updatedModel = profileEditModel
+     guard let self = self, let updatedText = updatedText else { return }
+     guard var updatedModel = self.delegate?.getProfileEditModel() else { return }
      updatedModel.fullName = updatedText
      self.delegate?.updateProfileEditModel(updatedModel)
  }

--- a/HW_OrderCoffeeApp/EditProfile/ViewControllers/EditProfileViewController.swift
+++ b/HW_OrderCoffeeApp/EditProfile/ViewControllers/EditProfileViewController.swift
@@ -313,10 +313,18 @@ class EditProfileViewController: UIViewController {
     
     // MARK: - Helper Methods ( saveButtonTapped )
 
-    /// 驗證必填欄位
+    /// 驗證必填欄位，確保 `fullName` 不是空值或只有空格。
+    ///
+    /// - 會自動移除 `fullName` 前後的空格後再進行驗證。
+    /// - 若 `fullName` 為空字串 (`""`) 或只包含空格，則會顯示錯誤提示並禁止存取。
+    ///
+    /// - Parameter profile: 目前的 `ProfileEditModel`，用於檢查 `fullName` 是否有效。
+    /// - Returns: `true` 表示驗證通過，`false` 則表示 `fullName` 無效並顯示錯誤提示。    
     private func validateRequiredFields(for profile: ProfileEditModel) -> Bool {
-        if profile.fullName.isEmpty {
-            AlertService.showAlert(withTitle: "錯誤", message: "Full Name cannot be empty.", inViewController: self)
+        let trimmedFullName = profile.fullName.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        if trimmedFullName.isEmpty {
+            AlertService.showAlert(withTitle: "錯誤", message: "Full Name cannot be empty or spaces.", inViewController: self)
             return false
         }
         return true


### PR DESCRIPTION
This PR refactors the EditProfile module to improve parameter handling and validation:

- **EditProfileTableHandler.swift**:
  - `configureProfileImageCell` now takes `profileImageURL` instead of `ProfileEditModel`.
  - `configureGenderCell` now takes `gender` instead of `ProfileEditModel`.
  - `configureBirthdayCell` now takes `birthday` instead of `ProfileEditModel`.
  - Removed `configureTextFieldCell` model parameter to prevent outdated values.
  - Ensured input with only spaces is converted to an empty string to maintain data integrity.

- **EditProfileViewController.swift**:
  - Improved `validateRequiredFields` to trim `fullName` before validation, ensuring it's not empty or only spaces.

This refactor improves data integrity, reduces unnecessary dependencies, and enhances maintainability.
